### PR TITLE
[FIX] one_way_filter에서 missing value filter 기능 수정

### DIFF
--- a/mining/preprocessing.py
+++ b/mining/preprocessing.py
@@ -217,9 +217,10 @@ def one_way_filter(df, colName = 'events', posCondition = ['strikeout']):
 
     # 4. 구종 Counts가 3개 이상인 정상 데이터만 추출
     condition2 = df_filtered.pitch_type == 'end'
-    condition3 = df_filtered[condition2].pitchOrder < 3
-    missing_list = df_filtered[condition2][condition3].processID
-    df_filtered = df[~(df['processID'].isin(missing_list))]
+    condition3 = df_filtered[condition2].pitchOrder >= 3
+    missing_list = df_filtered[condition2 & condition3].processID
+
+    df_filtered = df[df['processID'].isin(missing_list)]
 
     return df_filtered
 


### PR DESCRIPTION
3개 미만의 sequence는 제거하는 필터가 제대로 동작하지 않아서 전체 필터 기능이 동작하지 않게 되었다. 제대로 동작하도록 수정하였다.