### PR TITLE
[FEAT] 평가지표(Sabermetrics : P/PA, K/PA, FIP) 추가

### DIFF
--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,0 +1,9 @@
+from .saber import p_per_pa
+from .saber import k_per_pa
+from .saber import fip
+
+__all__ = [
+    'p_per_pa',
+    'k_per_pa',
+    'fip'
+]

--- a/metrics/saber.py
+++ b/metrics/saber.py
@@ -1,0 +1,141 @@
+import pandas as pd
+
+def p_per_pa(df_filtered):
+    results = []
+
+    c = 'all'
+    pitches = len(df_filtered)
+    pa = df_filtered['ProcessID'].nunique()
+    p_pa = pitches/pa
+    
+    results.append({
+                "unit": c,
+                "pitches": pitches,
+                "PA": pa,
+                "P/PA": p_pa
+            })
+
+    if ('unit' in df_filtered.columns):
+        for c, group in df_filtered.groupby("cluster"):
+            pitches = len(group)                     # 총 투구 수(P)
+            pa = group["processID"].nunique()        # 고유 타석 수(PA)
+            p_pa = pitches / pa                      # P/PA
+
+            results.append({
+                "unit": c,
+                "pitches": pitches,
+                "PA": pa,
+                "P/PA": p_pa
+            })
+
+    df_result = pd.DataFrame(results).sort_values("unit").reset_index(drop=True)
+    p_pa_dict = {row["unit"]: row["P/PA"] for row in results}
+    return p_pa_dict, df_result
+
+
+
+def k_per_pa(df_filtered):
+    df_end = df_filtered[df_filtered["pitch_type"] == "end"]
+
+    results = []
+    c = 'all'
+    pa = df_filtered["processID"].nunique()
+    strikeouts = (df_filtered["events"] == "strikeout").sum()       
+    kpa = strikeouts / pa
+
+    results.append({
+        "cluster": c,
+        "PA": pa,
+        "K": strikeouts,
+        "K/PA": kpa
+    })
+
+    if ('cluster' in df_filtered.columns):
+        for c, group in df_end.groupby("cluster"):
+            pa = group["processID"].nunique()
+            strikeouts = (group["events"] == "strikeout").sum()
+            
+            kpa = strikeouts / pa
+
+            results.append({
+                "cluster": c,
+                "PA": pa,
+                "K": strikeouts,
+                "K/PA": kpa
+            })
+
+    df_result = pd.DataFrame(results).sort_values("cluster").reset_index(drop=True)
+    kpa_dict = {row["cluster"]: row["K/PA"] for row in results}
+    return kpa_dict, df_result
+
+
+# def fip(df_filtered, total_IP=60, constant=3.1):
+#     df_end = df_filtered[df_filtered["pitch_type"] == "end"]
+
+#     cluster_stats = (
+#         df_end.groupby("cluster")
+#         .agg(
+#             PA=("processID", "nunique"),
+#             K=("events", lambda x: (x == "strikeout").sum()),
+#             BB=("events", lambda x: (x == "walk").sum()),
+#             HBP=("events", lambda x: (x == "hit_by_pitch").sum()),
+#             HR=("events", lambda x: (x == "home_run").sum())
+#         )
+#     )
+#     IP_criteria = ["strikeout", "field_out", "force_out", "grounded_into_double_play", "double_play", "sac_fly", "sac_bunt"]
+#     cluster_stats["IP"] = (cluster_stats["PA"] / total_PA) * total_IP
+#     total_PA = df_end["processID"].nunique()
+
+#     cluster_stats["FIP"] = (
+#         (13 * cluster_stats["HR"] +
+#          3 * (cluster_stats["BB"] + cluster_stats["HBP"]) -
+#          2 * cluster_stats["K"]) / cluster_stats["IP"]
+#         + constant
+#     )
+    
+#     return cluster_stats
+
+def fip(df_filtered, constant=3.1):
+
+    # 아웃으로 잡을 이벤트들
+    IP_criteria = [
+        "strikeout",
+        "field_out",
+        "force_out",
+        "grounded_into_double_play",
+        "double_play",
+        "sac_fly",
+        "sac_bunt",
+    ]
+
+    # cluster 컬럼 유무에 따라 그룹핑 대상 결정
+    group_cols = "cluster" if "cluster" in df_filtered.columns else "pitcher"
+
+    # 기본 카운트들
+    cluster_stats = (
+        df_filtered.groupby(group_cols, dropna=False)
+        .agg(
+            PA=("processID", "nunique"),
+            K=("events", lambda x: (x == "strikeout").sum()),
+            BB=("events", lambda x: (x == "walk").sum()),
+            HBP=("events", lambda x: (x == "hit_by_pitch").sum()),
+            HR=("events", lambda x: (x == "home_run").sum()),
+            OUTS=("events", lambda x: x.isin(IP_criteria).sum()),
+        )
+    )
+
+    # 클러스터별 IP = OUTS / 3
+    cluster_stats["IP"] = cluster_stats["OUTS"] / 3.0
+
+    # IP가 0인 경우 분모 0 방지
+    cluster_stats = cluster_stats[cluster_stats["IP"] > 0].copy()
+
+    # FIP 계산
+    cluster_stats["FIP"] = (
+        (13 * cluster_stats["HR"]
+         + 3 * (cluster_stats["BB"] + cluster_stats["HBP"])
+         - 2 * cluster_stats["K"]) / cluster_stats["IP"]
+        + constant
+    )
+
+    return cluster_stats


### PR DESCRIPTION
### 개요
본 PR은 야구 세이버메트릭스 분석을 위한 투수 성과 지표 계산 모듈을 추가하여 아래의 세 가지 지표를 신규로 지원합니다.
해당 지표들은 투수의 효율성, 삼진 능력, 수비 독립적 실력을 정량적으로 평가하는 데 목적이 있습니다.

- P/PA: Plate Appearance 당 투구 수
- K/PA: Plate Appearance 당 탈삼진 비율
- FIP: Fielding Independent Pitching

---

### 1. P/PA (Pitches per Plate Appearance)
- 정의: 한 타석당 평균 투구 수
- 수식:
  P/PA = Total Pitches / Plate Appearances
- 의미:
  - 투수의 타자 상대 효율성 측정
  - 낮을수록 빠른 아웃카운트 유도 가능


### 2. K/PA (Strikeouts per Plate Appearance)
- 정의: 타석 대비 탈삼진 비율
- 수식:
  K/PA = Strikeouts / Plate Appearances
- 의미:
  - 투수의 삼진 유도 능력 정량화
  - 구속, 구위, 결정구 영향 분석에 활용 가능


### 3. FIP (Fielding Independent Pitching)
- 정의: 수비 영향을 제거한 투수 성과 지표
- 수식:
  FIP = (13 × HR + 3 × (BB + HBP) − 2 × K) / IP + constant
- 의미:
  - 투수의 진짜 실력(true talent) 평가
  - 수비력·운 요소를 배제한 비교 가능

---

### 구현 내용
- Dataframe  feeding으로 계산이 가능하다록 설계
- 분모가 0인 경우를 고려한 안전한 예외 처리
